### PR TITLE
fix:deno_core包可能导致once cell依赖的版本问题

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 yaml-rust = "0.4.5"
 lazy_static = "1.4.0"
 bimap = "0.6.1"
-deno_core = "0.121.0"
+deno_core = "0.173.0"
 log = "0.4.14"
 simplelog = "0.12.0"
 clap = { version = "3.0.14", features = ["derive"] }


### PR DESCRIPTION
- 修复一个由于deno_core包版本太低可能导致其他依赖包的依赖关系不满足的问题