### PR TITLE
fix: return an error for Logger initialization instead of printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ use dagrs::{
 };
 
 struct SimpleAction(usize);
-/// Implement the `Action` trait for `SimpleAction`, defining the logic of the `run` function. 
+/// Implement the `Action` trait for `SimpleAction`, defining the logic of the `run` function.
 /// The logic here is simply to get the output value (`usize`) of all predecessor tasks and then accumulate.
 impl Action for SimpleAction{
     fn run(&self, input: Input,env:Arc<EnvVar>) -> Result<Output,RunningError> {
@@ -77,7 +77,7 @@ impl Action for SimpleAction{
 }
 
 // Initialize the global logger
-log::init_logger(LogLevel::Info,None);
+let _initialized = log::init_logger(LogLevel::Info,None);
 // Generate four tasks.
 let a= DefaultTask::new(SimpleAction(10),"Task a");
 let mut b=DefaultTask::new(SimpleAction(20),"Task b");
@@ -119,7 +119,7 @@ flowchart LR;
 	A((Task a))-->B;	A-->C;	B((Task b))-->D;	C((Task c))-->D((Task d));
 ```
 
-The execution order is a->c->b->d. 
+The execution order is a->c->b->d.
 
 ```bash
 $cargo run
@@ -255,7 +255,7 @@ You can see an example: `examples/yaml_dag.rs`.  In fact, you can also programma
   	tasks==Generate execution sequence based on topological sort==>seq
   ```
 
-  
+
 
 - The task is scheduled to start executing asynchronously.
 
@@ -282,11 +282,11 @@ You can see an example: `examples/yaml_dag.rs`.  In fact, you can also programma
   	F-->of((out))
   ```
 
-  
+
 
 - If the result of the predecessor task can be obtained, check the continuation status`can_continue`, if it is true, continue to execute the defined logic, if it is false, trigger`handle_error`, and cancel the execution of the subsequent task.
 
-- After all tasks are executed, set the continuation status to false, which means that the tasks of the `dag` cannot be scheduled for execution again. 
+- After all tasks are executed, set the continuation status to false, which means that the tasks of the `dag` cannot be scheduled for execution again.
 
 The task execution mode of `dagrs` is parallel. In the figure, the execution sequence is divided into four intervals by the vertical dividing line. During the overall execution of the task, it will go through four parallel execution stages. As shown in the figure: first task A is executed, and tasks B and C obtain the output of A as the input of their own tasks and start to execute in parallel; similarly, tasks D and E must wait until they obtain the output of their predecessors before starting to execute in parallel; finally, Task F must wait for the execution of tasks B, D, and E to complete before it can start executing.
 

--- a/examples/compute_dag.rs
+++ b/examples/compute_dag.rs
@@ -37,7 +37,7 @@ macro_rules! generate_task {
 
 fn main() {
     // initialization log.
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     // generate some tasks.
     let a = generate_task!(A(1), "Compute A");
     let mut b = generate_task!(B(2), "Compute B");

--- a/examples/custom_log.rs
+++ b/examples/custom_log.rs
@@ -59,7 +59,7 @@ impl Logger for MyLogger {
 
 fn main() {
     // Initialize the global logger with a custom logger.
-    dagrs::log::init_custom_logger(MyLogger::new(LogLevel::Info));
+    let _initialized = dagrs::log::init_custom_logger(MyLogger::new(LogLevel::Info));
     let mut dag = Dag::with_yaml("tests/config/correct.yaml",HashMap::new()).unwrap();
     assert!(dag.start().unwrap());
 }

--- a/examples/custom_parser.rs
+++ b/examples/custom_parser.rs
@@ -1,6 +1,6 @@
 //! Implement the Parser interface to customize the task configuration file parser.
 //! The content of the configuration file is as follows:
-//! 
+//!
 //! ```
 //! a,Task a,b c,echo a
 //! b,Task b,c f g,echo b
@@ -138,7 +138,7 @@ impl Parser for ConfigParser {
 }
 
 fn main() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let file = "tests/config/custom_file_task.txt";
     let mut dag = Dag::with_config_file_and_parser(file, Box::new(ConfigParser),HashMap::new()).unwrap();
     assert!(dag.start().unwrap());

--- a/examples/custom_task.rs
+++ b/examples/custom_task.rs
@@ -64,7 +64,7 @@ macro_rules! generate_task {
 }
 
 fn main() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let a = generate_task!(A(1), "Compute A");
     let mut b = generate_task!(B(2), "Compute B");
     let mut c = generate_task!(C(4), "Compute C");

--- a/examples/engine.rs
+++ b/examples/engine.rs
@@ -9,7 +9,7 @@ use dagrs::{
 };
 fn main() {
     // initialization log.
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     // Create an Engine.
     let mut engine = Engine::default();
 

--- a/examples/impl_action.rs
+++ b/examples/impl_action.rs
@@ -26,7 +26,7 @@ impl Action for SimpleAction {
 
 fn main() {
     // Initialize the global logger
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     // Generate four tasks.
     let a = DefaultTask::new(SimpleAction(10), "Task a");
     let mut b = DefaultTask::new(SimpleAction(20), "Task b");

--- a/examples/use_macro.rs
+++ b/examples/use_macro.rs
@@ -15,7 +15,7 @@ use dagrs::{
 };
 
 fn main() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let a = gen_task!("Compute A", |_input: Input, _env: Arc<EnvVar>| Ok(
         Output::new(20usize)
     ));

--- a/examples/yaml_dag.rs
+++ b/examples/yaml_dag.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use dagrs::{log, Dag, LogLevel};
 
 fn main() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let mut job = Dag::with_yaml("tests/config/correct.yaml",HashMap::new()).unwrap();
     assert!(job.start().unwrap());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
             }
         }
     });
-    match args.log_path {
+    let _initialized = match args.log_path {
         None => {log::init_logger(log_level,None)}
         Some(path) => {log::init_logger(log_level,Some(std::fs::File::create(path).unwrap()))}
     };

--- a/src/utils/log.rs
+++ b/src/utils/log.rs
@@ -140,7 +140,7 @@ pub enum LoggerError {
 /// # Example
 ///
 /// ```rust
-/// use dagrs::{log, LogLevel, is_logger_initialized};
+/// use dagrs::{log, LogLevel};
 /// let _initialized = log::init_logger(LogLevel::Info,None);
 /// ```
 pub fn init_logger(fix_log_level: LogLevel, log_file: Option<File>) -> Result<(), LoggerError> {

--- a/tests/dag_job_test.rs
+++ b/tests/dag_job_test.rs
@@ -5,14 +5,14 @@ use dagrs::{Action, Dag, DagError, DefaultTask, EnvVar, Input, Output, RunningEr
 
 #[test]
 fn yaml_task_correct_execute() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let mut job = Dag::with_yaml("tests/config/correct.yaml",HashMap::new()).unwrap();
     assert!(job.start().unwrap());
 }
 
 #[test]
 fn yaml_task_loop_graph() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let res = Dag::with_yaml("tests/config/loop_error.yaml",HashMap::new())
         .unwrap()
         .start();
@@ -21,7 +21,7 @@ fn yaml_task_loop_graph() {
 
 #[test]
 fn yaml_task_self_loop_graph() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let res = Dag::with_yaml("tests/config/self_loop_error.yaml",HashMap::new())
         .unwrap()
         .start();
@@ -30,7 +30,7 @@ fn yaml_task_self_loop_graph() {
 
 #[test]
 fn yaml_task_failed_execute() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let res = Dag::with_yaml("tests/config/script_run_failed.yaml",HashMap::new())
         .unwrap()
         .start();
@@ -56,7 +56,7 @@ macro_rules! generate_task {
 
 #[test]
 fn task_loop_graph() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let mut a = generate_task!(A(1), "Compute A");
     let mut b = generate_task!(B(2), "Compute B");
     let mut c = generate_task!(C(4), "Compute C");
@@ -75,7 +75,7 @@ fn task_loop_graph() {
 
 #[test]
 fn non_job() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let tasks: Vec<DefaultTask> = Vec::new();
     let res = Dag::with_tasks(tasks).start();
     assert!(res.is_err());
@@ -101,7 +101,7 @@ impl Action for FailedActionD {
 
 #[test]
 fn task_failed_execute() {
-    log::init_logger(LogLevel::Info, None);
+    let _initialized = log::init_logger(LogLevel::Info, None);
     let a = generate_task!(A(1), "Compute A");
     let mut b = generate_task!(B(2), "Compute B");
     let mut c = DefaultTask::new(FailedActionC(0), "Compute C");


### PR DESCRIPTION
This changes the `init_logger` and `init_custom_logger` to return an error when the logger is already initialized instead of printing to the stdout.

This has multiple benefits:
- The error can be handled properly
- The error can be ignored if the user doesn't care about this particular error
