### PR TITLE
add a method to get the output from all tasks

### DIFF
--- a/src/engine/dag.rs
+++ b/src/engine/dag.rs
@@ -331,6 +331,18 @@ impl Dag {
         }
     }
 
+    pub fn get_results<T: CloneAnySendSync + Send + Sync>(&self) -> HashMap<usize,Option<T>> {
+		let mut hm = HashMap::new();
+		for (id,state) in &self.execute_states {
+			let output = match state.get_output() {
+				Some(ref content) => content.clone().remove(),
+				None => None,
+			};
+			hm.insert(*id,output);
+		}
+		hm
+    }
+
     /// Before the dag starts executing, set the dag's global environment variable.
     pub fn set_env(&mut self, env: EnvVar) {
         self.env = Arc::new(env);


### PR DESCRIPTION
It is very useful to be able to access the output of every task in a job not just the last one.

Created a method get_results similar to get_result to return a hashmap of all the task ids and their outputs.