### PR TITLE
feat: allow disabling the logger via a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,11 @@ clap = { version = "4.2.2", features = ["derive"] }
 anymap2 = "0.13.0"
 thiserror = "1.0.30"
 tokio = { version = "1.28", features = ["rt", "sync","rt-multi-thread"] }
+
+[dev-dependencies]
 log = "0.4"
 simplelog = "0.12"
+
+[features]
+default = ["logger"]
+logger = []

--- a/src/utils/default_logger.rs
+++ b/src/utils/default_logger.rs
@@ -1,0 +1,127 @@
+//! The default logger implementation when the `logger` feature is enabled.
+
+use std::{
+    fmt::Display,
+    fs::File,
+    io::Write,
+    sync::{Arc, Mutex},
+};
+
+use crate::{LogLevel, Logger, log::{LoggerError, LOG}};
+
+/// Default logger.
+pub(crate) struct DefaultLogger {
+    level: LogLevel,
+    log_pos: Option<Mutex<File>>,
+}
+
+impl DefaultLogger {
+    fn log(&self, msg: String) {
+        match self.log_pos {
+            Some(ref file) => {
+                let mut file = file.lock().unwrap();
+                let _ = writeln!(file, "{}", msg);
+            }
+            None => {
+                println!("{}", msg);
+            }
+        }
+    }
+}
+
+impl Logger for DefaultLogger {
+    fn level(&self) -> LogLevel {
+        self.level
+    }
+
+    fn debug(&self, msg: String) {
+        self.log(msg)
+    }
+
+    fn info(&self, msg: String) {
+        self.log(msg)
+    }
+
+    fn warn(&self, msg: String) {
+        self.log(msg)
+    }
+
+    fn error(&self, msg: String) {
+        self.log(msg)
+    }
+}
+
+impl Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogLevel::Debug => write!(f, "Debug"),
+            LogLevel::Info => write!(f, "Info"),
+            LogLevel::Warn => write!(f, "warn"),
+            LogLevel::Error => write!(f, "error"),
+            LogLevel::Off => write!(f, "off"),
+        }
+    }
+}
+
+/// Initialize the default logger, the user needs to specify the logging level of the logger,
+/// and can also specify the location of the log output, if the log_file parameter is passed in
+/// None, the log information will be printed to the terminal, otherwise, the log information
+/// will be output to the file.
+///
+/// # Example
+///
+/// ```rust
+/// use dagrs::{log, LogLevel};
+/// let _initialized = log::init_logger(LogLevel::Info,None);
+/// ```
+pub(crate) fn init_default_logger(fix_log_level: LogLevel, log_file: Option<File>) -> Result<(), LoggerError> {
+    let logger = match log_file {
+        Some(file) => DefaultLogger {
+            level: fix_log_level,
+            log_pos: Some(Mutex::new(file)),
+        },
+        None => DefaultLogger {
+            level: fix_log_level,
+            log_pos: None,
+        },
+    };
+    if LOG.set(Arc::new(logger)).is_err() {
+        return Err(LoggerError::AlreadyInitialized);
+    }
+    Ok(())
+}
+
+pub(crate) fn get_logger() -> Arc<dyn Logger + Send + Sync + 'static> {
+    LOG.get().expect("Logger is not initialized!").clone()
+}
+
+/// The following `debug`, `info`, `warn`, and `error` functions are the recording functions
+/// provided by the logger for users.
+
+pub(crate) fn default_debug(msg: String) {
+    let logger = get_logger();
+    if logger.level().check_level(LogLevel::Debug) {
+        logger.debug(msg);
+    }
+}
+
+pub(crate) fn default_info(msg: String) {
+    let logger = get_logger();
+    if logger.level().check_level(LogLevel::Info) {
+        logger.info(msg);
+    }
+}
+
+pub(crate) fn default_warn(msg: String) {
+    let logger = get_logger();
+    if logger.level().check_level(LogLevel::Warn) {
+        logger.warn(msg);
+    }
+}
+
+pub(crate) fn default_error(msg: String) {
+    let logger = get_logger();
+    if logger.level().check_level(LogLevel::Error) {
+        logger.error(msg);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,14 +1,17 @@
 //! general tool.
-//! 
+//!
 //! # dagrs tool module.
-//! 
+//!
 //! This module contains common tools for the program, such as: loggers, environment
 //! variables, task generation macros.
 
 #[macro_use]
 pub mod gen_macro;
 mod env;
+
 pub mod log;
+#[cfg(feature = "logger")]
+mod default_logger;
 
 pub use self::env::EnvVar;
 pub use self::log::{LogLevel,Logger};


### PR DESCRIPTION
This moves the default logger implementation to a separate file. The common methods remain in the log module, but they can become no-op when the `logger` feature is disabled via `default-features=false`