### PR TITLE
feat: implement Error trait for all error types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.features": "all"
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.2.2", features = ["derive"] }
 anymap2 = "0.13.0"
 tokio = { version = "1.28", features = ["rt", "sync","rt-multi-thread"] }
 derive ={ path = "derive", version = "0.3.0" }
+thiserror = "1.0.50"
 
 [dev-dependencies]
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Among them, each task may produce output, and may also require the output of som
 
 ### Programmatically implement task definition
 
-Users need to program to implement the `Action` trait to define the specific logic of the task, and then build a series of `DefaultTask`. 
+Users need to program to implement the `Action` trait to define the specific logic of the task, and then build a series of `DefaultTask`.
 
 First, users need to define some specific task logic. There are two ways to define task logic:
 
@@ -70,7 +70,7 @@ Finally, don’t forget to initialize the logger, and then you can call the `sta
 You can refer to an example for the above complete steps: `examples/compute_dag.rs`
 
 
-Here is the `examples/impl_action.rs` example:
+Here is the `examples/compute_dag.rs` example:
 
 ```rust
 //! Only use Dag, execute a job. The graph is as follows:

--- a/examples/compute_dag.rs
+++ b/examples/compute_dag.rs
@@ -11,8 +11,8 @@
 
 extern crate dagrs;
 
-use std::sync::Arc;
 use dagrs::{log, Complex, Dag, DefaultTask, EnvVar, Input, LogLevel, Output};
+use std::sync::Arc;
 
 struct Compute(usize);
 

--- a/examples/custom_parser_and_task.rs
+++ b/examples/custom_parser_and_task.rs
@@ -89,16 +89,16 @@ impl ConfigParser {
     }
 
     fn parse_one(&self, item: String) -> MyTask {
-        let attr: Vec<&str> = item.split(",").collect();
+        let attr: Vec<&str> = item.split(',').collect();
 
         let pres_item = *attr.get(2).unwrap();
         let pres = if pres_item.eq("") {
             Vec::new()
         } else {
-            pres_item.split(" ").map(|pre| pre.to_string()).collect()
+            pres_item.split(' ').map(|pre| pre.to_string()).collect()
         };
 
-        let id = *attr.get(0).unwrap();
+        let id = *attr.first().unwrap();
         let name = attr.get(1).unwrap().to_string();
         let cmd = *attr.get(3).unwrap();
         MyTask::new(id, pres, name, CommandAction::new(cmd))

--- a/examples/dependencies.rs
+++ b/examples/dependencies.rs
@@ -54,13 +54,13 @@ fn main() {
             g ->
     );
     let mut x = 1;
-    for index in 0..4 {
-        tasks[index].set_action(Compute(x * 2));
+    for task in tasks.iter_mut().take(4) {
+        task.set_action(Compute(x * 2));
         x *= 2;
     }
 
-    for index in 4..7 {
-        tasks[index].set_closure(|input, env| {
+    for task in tasks.iter_mut().skip(4) {
+        task.set_closure(|input, env| {
             let base = env.get::<usize>("base").unwrap();
             let mut sum = 0;
             input

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -1,6 +1,8 @@
 //! Task configuration file parser interface
+use thiserror::Error;
+
 use crate::{task::Task, Action};
-use std::{collections::HashMap, error::Error, fmt::Display};
+use std::{collections::HashMap, error::Error};
 
 /// Generic parser traits. If users want to customize the configuration file parser, they must implement this trait.
 /// The yaml module's `YamlParser` is an example.
@@ -29,14 +31,9 @@ pub trait Parser {
 /// This structure stores error information. Users need to customize error types and implement conversion
 /// from custom error types to [`ParseError`].
 /// By default, a conversion from `String` type to [`ParseError`] is provided.
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("{0}")]
 pub struct ParseError(pub Box<dyn Error>);
-
-impl Display for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0.to_string())
-    }
-}
 
 impl From<String> for ParseError {
     fn from(value: String) -> Self {

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -2,7 +2,7 @@
 use thiserror::Error;
 
 use crate::{task::Task, Action};
-use std::{collections::HashMap, error::Error};
+use std::collections::HashMap;
 
 /// Generic parser traits. If users want to customize the configuration file parser, they must implement this trait.
 /// The yaml module's `YamlParser` is an example.
@@ -33,10 +33,10 @@ pub trait Parser {
 /// By default, a conversion from `String` type to [`ParseError`] is provided.
 #[derive(Debug, Error)]
 #[error("{0}")]
-pub struct ParseError(pub Box<dyn Error>);
+pub struct ParseError(pub String);
 
 impl From<String> for ParseError {
     fn from(value: String) -> Self {
-        ParseError(value.into())
+        ParseError(value)
     }
 }

--- a/tests/dag_job_test.rs
+++ b/tests/dag_job_test.rs
@@ -1,6 +1,7 @@
+//! Some tests of the dag engine.
+
 use std::{collections::HashMap, sync::Arc};
 
-///! Some tests of the dag engine.
 use dagrs::{log, Complex, Dag, DagError, DefaultTask, EnvVar, Input, LogLevel, Output};
 
 #[test]


### PR DESCRIPTION
This implements `thiserror::Error` for all error types of the package. This has many benefits such as the possibility to use `?`, standard conversion to/from other error types, and simplification of error handling.