### PR TITLE
feat: support dynamic action/tasks + relax the lifetime constraints

### DIFF
--- a/examples/compute_dag.rs
+++ b/examples/compute_dag.rs
@@ -11,8 +11,8 @@
 
 extern crate dagrs;
 
-use std::sync::Arc;
 use dagrs::{log, Complex, Dag, DefaultTask, EnvVar, Input, LogLevel, Output};
+use std::sync::Arc;
 
 struct Compute(usize);
 

--- a/src/engine/dag.rs
+++ b/src/engine/dag.rs
@@ -93,6 +93,15 @@ impl Dag {
         dag
     }
 
+    /// Create a dag by adding a series of tasks that implement the [`Task`] trait.
+    pub fn with_tasks_dyn(tasks: Vec<Arc<Box<dyn Task>>>) -> Dag {
+        let mut dag = Dag::new();
+        tasks.into_iter().for_each(|task| {
+            dag.tasks.insert(task.id(), task);
+        });
+        dag
+    }
+
     /// Given a yaml configuration file parsing task to generate a dag.
     #[cfg(feature = "yaml")]
     pub fn with_yaml(

--- a/src/task/action.rs
+++ b/src/task/action.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 /// The type of closure that performs logic.
 /// # [`Simple`]
 ///
-/// The specific type of [`Simple`] is `dyn Fn(Input, Arc<EnvVar>) -> Output + Send + Sync + 'static`,
+/// The specific type of [`Simple`] is `dyn Fn(Input, Arc<EnvVar>) -> Output + Send + Sync`,
 /// which represents a closure.
 ///
 /// # Example
@@ -16,7 +16,7 @@ use std::sync::Arc;
 /// let closure=|_input,_env|Output::new(10);
 /// let action=Action::Closure(Arc::new(closure));
 /// ```
-pub type Simple = dyn Fn(Input, Arc<EnvVar>) -> Output + Send + Sync + 'static;
+pub type Simple = dyn Fn(Input, Arc<EnvVar>) -> Output + Send + Sync;
 
 /// More complex types of execution logic.
 /// # [`Complex`]
@@ -57,14 +57,14 @@ pub trait Complex {
 /// Task specific behavior
 ///
 /// [`Action`] stores the specific execution logic of a task. Action::Closure(Arc<[`Simple`]>) represents a
-/// closure, and Action::Structure(Arc<dyn Complex + Send + Sync + 'static>) represents a specific type that
+/// closure, and Action::Structure(Arc<dyn Complex + Send + Sync>) represents a specific type that
 /// implements the [`Complex`] trait.
 /// Attributes that must exist in each task are used to store specific execution logic. Specific
 /// execution logic can be given in two forms: given a closure or a specific type that implements
 /// a Complex trait.
 pub enum Action {
     Closure(Arc<Simple>),
-    Structure(Arc<dyn Complex + Send + Sync + 'static>),
+    Structure(Arc<dyn Complex + Send + Sync>),
 }
 
 impl Action {

--- a/src/task/default_task.rs
+++ b/src/task/default_task.rs
@@ -83,9 +83,15 @@ impl DefaultTask {
     /// Create a task, give the task name, and provide a specific type that implements the [`Complex`] trait as the specific
     /// execution logic of the task.
     pub fn with_action(name: &str, action: impl Complex + Send + Sync + 'static) -> Self {
+        Self::with_action_dyn(name, Arc::new(action))
+    }
+
+    /// Create a task, give the task name, and provide a dynamic task that implements the [`Complex`] trait as the specific
+    /// execution logic of the task.
+    pub fn with_action_dyn(name: &str, action: Arc<dyn Complex + Send + Sync>) -> Self {
         DefaultTask {
             id: ID_ALLOCATOR.alloc(),
-            action: Action::Structure(Arc::new(action)),
+            action: Action::Structure(action),
             name: name.to_owned(),
             precursors: Vec::new(),
         }
@@ -96,9 +102,17 @@ impl DefaultTask {
         name: &str,
         action: impl Fn(Input, Arc<EnvVar>) -> Output + Send + Sync + 'static,
     ) -> Self {
+        Self::with_closure_dyn(name, Arc::new(action))
+    }
+
+    /// Create a task, give the task name, and provide a closure as the specific execution logic of the task.
+    pub fn with_closure_dyn(
+        name: &str,
+        action: Arc<dyn Fn(Input, Arc<EnvVar>) -> Output + Send + Sync>,
+    ) -> Self {
         DefaultTask {
             id: ID_ALLOCATOR.alloc(),
-            action: Action::Closure(Arc::new(action)),
+            action: Action::Closure(action),
             name: name.to_owned(),
             precursors: Vec::new(),
         }

--- a/src/utils/default_logger.rs
+++ b/src/utils/default_logger.rs
@@ -97,7 +97,7 @@ pub(crate) fn init_default_logger(
     Ok(())
 }
 
-pub(crate) fn get_logger() -> Arc<dyn Logger + Send + Sync + 'static> {
+pub(crate) fn get_logger() -> Arc<dyn Logger + Send + Sync> {
     LOG.get().expect("Logger is not initialized!").clone()
 }
 

--- a/src/utils/log.rs
+++ b/src/utils/log.rs
@@ -83,7 +83,7 @@ impl Display for LoggerError {
 }
 
 /// Logger instance.
-pub(crate) static LOG: OnceLock<Arc<dyn Logger + Sync + Send + 'static>> = OnceLock::new();
+pub(crate) static LOG: OnceLock<Arc<dyn Logger + Sync + Send>> = OnceLock::new();
 
 /// Initialize the default logger, the user needs to specify the logging level of the logger,
 /// and can also specify the location of the log output, if the log_file parameter is passed in
@@ -119,7 +119,11 @@ pub fn init_logger(fix_log_level: LogLevel, log_file: Option<File>) -> Result<()
 /// ```
 
 pub fn init_custom_logger(logger: impl Logger + Send + Sync + 'static) -> Result<(), LoggerError> {
-    if LOG.set(Arc::new(logger)).is_err() {
+    init_custom_logger_dyn(Arc::new(logger))
+}
+
+pub fn init_custom_logger_dyn(logger: Arc<dyn Logger + Send + Sync>) -> Result<(), LoggerError> {
+    if LOG.set(logger).is_err() {
         return Err(LoggerError::AlreadyInitialized);
     }
     Ok(())


### PR DESCRIPTION
- This adds the `_dyn` variation of the methods that allows passing dynamic tasks/actions 
- Relaxes the `'static` lifetime requirements

It reimplements #36 for #37 